### PR TITLE
Update from Source: Bump game server image (shows entity information hp and blast_diamete…

### DIFF
--- a/base-compose.yml
+++ b/base-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
     game-server:
-        image: coderone.azurecr.io/game-server:345
+        image: coderone.azurecr.io/game-server:365
 
     python3-agent:
         build:

--- a/python3/game_state.py
+++ b/python3/game_state.py
@@ -77,6 +77,10 @@ class GameState:
             elif event_type == "agent_state":
                 payload = event.get("data")
                 self._on_agent_state(payload)
+            elif event_type == "entity_state":
+                x, y = event.get("coordinates")
+                updated_entity = event.get("updated_entity")
+                self._on_entity_state(x, y, updated_entity)
             else:
                 print(f"unknown event type {event_type}: {event}")
         if self._tick_callback is not None:
@@ -103,6 +107,12 @@ class GameState:
     def _on_agent_state(self, agent_state):
         agent_number = agent_state.get("number")
         self._state["agent_state"][str(agent_number)] = agent_state
+
+    def _on_entity_state(self, x, y, updated_entity):
+        for entity in self._state.get("entities"):
+            if entity.get("x") == x and entity.get("y") == y:
+                self._state["entities"].remove(entity)
+        self._state["entities"].append(updated_entity)
 
     def _on_agent_action(self, action_data):
         [agent_number, action_packet] = action_data

--- a/validation.schema.json
+++ b/validation.schema.json
@@ -194,6 +194,9 @@
                                     "items": {
                                         "additionalProperties": false,
                                         "properties": {
+                                            "blast_diameter": {
+                                                "type": "number"
+                                            },
                                             "expires": {
                                                 "type": "number"
                                             },
@@ -493,9 +496,84 @@
                                             {
                                                 "additionalProperties": false,
                                                 "properties": {
+                                                    "coordinates": {
+                                                        "items": [
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "number"
+                                                            }
+                                                        ],
+                                                        "maxItems": 2,
+                                                        "minItems": 2,
+                                                        "type": "array"
+                                                    },
+                                                    "type": {
+                                                        "enum": [
+                                                            "entity_state"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "updated_entity": {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "blast_diameter": {
+                                                                "type": "number"
+                                                            },
+                                                            "expires": {
+                                                                "type": "number"
+                                                            },
+                                                            "hp": {
+                                                                "type": "number"
+                                                            },
+                                                            "owner": {
+                                                                "type": "number"
+                                                            },
+                                                            "type": {
+                                                                "enum": [
+                                                                    "a",
+                                                                    "b",
+                                                                    "bp",
+                                                                    "m",
+                                                                    "o",
+                                                                    "t",
+                                                                    "w",
+                                                                    "x"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "x": {
+                                                                "type": "number"
+                                                            },
+                                                            "y": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "x",
+                                                            "y"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "coordinates",
+                                                    "type",
+                                                    "updated_entity"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "additionalProperties": false,
+                                                "properties": {
                                                     "data": {
                                                         "additionalProperties": false,
                                                         "properties": {
+                                                            "blast_diameter": {
+                                                                "type": "number"
+                                                            },
                                                             "expires": {
                                                                 "type": "number"
                                                             },
@@ -748,6 +826,9 @@
                                     "items": {
                                         "additionalProperties": false,
                                         "properties": {
+                                            "blast_diameter": {
+                                                "type": "number"
+                                            },
                                             "expires": {
                                                 "type": "number"
                                             },
@@ -973,9 +1054,84 @@
                                                         {
                                                             "additionalProperties": false,
                                                             "properties": {
+                                                                "coordinates": {
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        }
+                                                                    ],
+                                                                    "maxItems": 2,
+                                                                    "minItems": 2,
+                                                                    "type": "array"
+                                                                },
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "entity_state"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "updated_entity": {
+                                                                    "additionalProperties": false,
+                                                                    "properties": {
+                                                                        "blast_diameter": {
+                                                                            "type": "number"
+                                                                        },
+                                                                        "expires": {
+                                                                            "type": "number"
+                                                                        },
+                                                                        "hp": {
+                                                                            "type": "number"
+                                                                        },
+                                                                        "owner": {
+                                                                            "type": "number"
+                                                                        },
+                                                                        "type": {
+                                                                            "enum": [
+                                                                                "a",
+                                                                                "b",
+                                                                                "bp",
+                                                                                "m",
+                                                                                "o",
+                                                                                "t",
+                                                                                "w",
+                                                                                "x"
+                                                                            ],
+                                                                            "type": "string"
+                                                                        },
+                                                                        "x": {
+                                                                            "type": "number"
+                                                                        },
+                                                                        "y": {
+                                                                            "type": "number"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "x",
+                                                                        "y"
+                                                                    ],
+                                                                    "type": "object"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "coordinates",
+                                                                "type",
+                                                                "updated_entity"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
                                                                 "data": {
                                                                     "additionalProperties": false,
                                                                     "properties": {
+                                                                        "blast_diameter": {
+                                                                            "type": "number"
+                                                                        },
                                                                         "expires": {
                                                                             "type": "number"
                                                                         },
@@ -1189,6 +1345,9 @@
                                             "items": {
                                                 "additionalProperties": false,
                                                 "properties": {
+                                                    "blast_diameter": {
+                                                        "type": "number"
+                                                    },
                                                     "expires": {
                                                         "type": "number"
                                                     },
@@ -1395,6 +1554,9 @@
                                             "items": {
                                                 "additionalProperties": false,
                                                 "properties": {
+                                                    "blast_diameter": {
+                                                        "type": "number"
+                                                    },
                                                     "expires": {
                                                         "type": "number"
                                                     },


### PR DESCRIPTION
…r) +python starter: handling entity_state event to account for changing hp of blocks (#27)

* Create game_state.py

handling entity_state event to account for changing hp of ore blocks

* Bump image + update schema

Co-authored-by: Matthew <thegalah@gmail.com>